### PR TITLE
Remove whitelist from github actions auto merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,16 +31,7 @@
       "matchFileNames": [".github/workflows/**"],
       "matchManagers": ["github-actions"],
       "automerge": true,
-      "automergeType": "pr",
-      "matchPackageNames": [
-        "/.*codespell.*/",
-        "/.*lint.*/",
-        "/.*dockle.*/",
-        "/.*trivy.*/",
-        "/.*anchore.*/",
-        "/.*scan.*/",
-        "/.*codeql.*/"
-      ]
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust Renovate auto-merge configuration for GitHub Actions by removing the previous whitelist behavior.