### PR TITLE
Drop separate codespell check, super linter 8.4.0 added this

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -18,20 +18,6 @@ env:
   IMAGE_NAME: nscan
 
 jobs:
-  codespell:
-    name: codespell
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Codespell
-        uses: codespell-project/actions-codespell@v2.2
-        with:
-          skip: .git
-          check_filenames: true
-          check_hidden: true
   super-linter:
     name: super-linter
     strategy:
@@ -76,7 +62,6 @@ jobs:
           sarif_file: reports
   test-build:
     needs:
-      - codespell
       - super-linter
       - shiftleft
     strategy:


### PR DESCRIPTION
## Summary by Sourcery

Remove the dedicated codespell job from the GitHub Actions workflow now that super-linter includes codespell checks, and simplify the test-build job dependencies accordingly.

CI:
- Remove the standalone codespell workflow job in favor of codespell checks provided by super-linter.
- Update the test-build job to depend only on super-linter and shiftleft now that the separate codespell job is removed.